### PR TITLE
Define GameRepository port and in-memory adapter

### DIFF
--- a/src/main/java/com/frankint/battleship/application/adapter/persistence/InMemoryGameRepository.java
+++ b/src/main/java/com/frankint/battleship/application/adapter/persistence/InMemoryGameRepository.java
@@ -1,0 +1,36 @@
+package com.frankint.battleship.application.adapter.persistence;
+
+import com.frankint.battleship.application.port.out.GameRepository;
+import com.frankint.battleship.domain.model.Game;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Adapter for storing games in memory.
+ * Useful for testing and early development phases.
+ */
+@Repository
+public class InMemoryGameRepository implements GameRepository {
+
+    // ConcurrentHashMap is crucial here for thread safety in a multiplayer environment
+    private final Map<String, Game> store = new ConcurrentHashMap<>();
+
+    @Override
+    public Game save(Game game) {
+        store.put(game.getId(), game);
+        return game;
+    }
+
+    @Override
+    public Optional<Game> findById(String gameId) {
+        return Optional.ofNullable(store.get(gameId));
+    }
+
+    @Override
+    public void delete(String gameId) {
+        store.remove(gameId);
+    }
+}

--- a/src/main/java/com/frankint/battleship/application/port/out/GameRepository.java
+++ b/src/main/java/com/frankint/battleship/application/port/out/GameRepository.java
@@ -1,0 +1,11 @@
+package com.frankint.battleship.application.port.out;
+
+import com.frankint.battleship.domain.model.Game;
+
+import java.util.Optional;
+
+public interface GameRepository {
+    Game save(Game game);
+    Optional<Game> findById(String gameId);
+    void delete(String gameId);
+}

--- a/src/test/java/com/frankint/battleship/application/port/out/InMemoryGameRepositoryTest.java
+++ b/src/test/java/com/frankint/battleship/application/port/out/InMemoryGameRepositoryTest.java
@@ -1,0 +1,21 @@
+package com.frankint.battleship.application.port.out;
+
+import com.frankint.battleship.application.adapter.persistence.InMemoryGameRepository;
+import com.frankint.battleship.domain.model.Board;
+import com.frankint.battleship.domain.model.Game;
+import com.frankint.battleship.domain.model.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InMemoryGameRepositoryTest {
+    @Test
+    public void testBasic() {
+        InMemoryGameRepository repository = new InMemoryGameRepository();
+        Game game = new Game(new Player("p1", new Board(10, 10)));
+        assertEquals(game, repository.save(game));
+        assertEquals(game, repository.findById(game.getId()).get());
+        repository.delete(game.getId());
+        assertTrue(repository.findById(game.getId()).isEmpty());
+    }
+}


### PR DESCRIPTION
Created GameRepository interface in the application layer.

Defined methods: save(Game game), findById(String id).

Created a temporary InMemoryGameRepository implementation using a ConcurrentHashMap for testing.
Closes #11 .